### PR TITLE
Adding contact_block module which allows to add contact form as block

### DIFF
--- a/config/default/block.block.bartik_content.yml
+++ b/config/default/block.block.bartik_content.yml
@@ -11,7 +11,7 @@ _core:
 id: bartik_content
 theme: bartik
 region: content
-weight: 0
+weight: -3
 provider: null
 plugin: system_main_block
 settings:

--- a/config/default/block.block.bartik_help.yml
+++ b/config/default/block.block.bartik_help.yml
@@ -11,7 +11,7 @@ _core:
 id: bartik_help
 theme: bartik
 region: content
-weight: -8
+weight: -7
 provider: null
 plugin: help_block
 settings:

--- a/config/default/block.block.bartik_local_actions.yml
+++ b/config/default/block.block.bartik_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_local_actions
 theme: bartik
 region: content
-weight: -8
+weight: -5
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/default/block.block.bartik_local_tasks.yml
+++ b/config/default/block.block.bartik_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_local_tasks
 theme: bartik
 region: content
-weight: -8
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/default/block.block.bartik_page_title.yml
+++ b/config/default/block.block.bartik_page_title.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_page_title
 theme: bartik
 region: content
-weight: -8
+weight: -6
 provider: null
 plugin: page_title_block
 settings:

--- a/config/default/block.block.contactblock.yml
+++ b/config/default/block.block.contactblock.yml
@@ -1,0 +1,27 @@
+uuid: 3ac13e67-fdf7-409d-aa6f-780612626c12
+langcode: en
+status: true
+dependencies:
+  module:
+    - contact_block
+    - system
+  theme:
+    - bartik
+id: contactblock
+theme: bartik
+region: content
+weight: -2
+provider: null
+plugin: contact_block
+settings:
+  id: contact_block
+  label: 'Contact Us'
+  provider: contact_block
+  label_display: visible
+  contact_form: contact_us
+visibility:
+  request_path:
+    id: request_path
+    pages: /become-sponser
+    negate: false
+    context_mapping: {  }

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -9,6 +9,7 @@ module:
   comment: 0
   config: 0
   contact: 0
+  contact_block: 0
   contextual: 0
   ctools: 0
   datetime: 0

--- a/docroot/modules/contrib/contact_block/LICENSE.txt
+++ b/docroot/modules/contrib/contact_block/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/docroot/modules/contrib/contact_block/README.txt
+++ b/docroot/modules/contrib/contact_block/README.txt
@@ -1,0 +1,52 @@
+INTRODUCTION
+------------
+The Contact Block module provides you with contact forms in a block. It extends
+Drupal core's Contact module which provides the forms.
+
+ * Visit the module's project page:
+   https://drupal.org/project/contact_block
+
+REQUIREMENTS
+------------
+This module requires the following modules:
+
+* Contact module (Drupal core)
+
+INSTALLATION
+------------
+Install as you would normally install a contributed Drupal module. See:
+  https://www.drupal.org/documentation/install/modules-themes/modules-8
+  for further information.
+
+CONFIGURATION
+-------------
+Create a contact form
+ - Home > Administation > Structure > Contact forms
+ - Edit (or delete) the default contact forms. Use Manage fields to add, update
+   or remove fields of the form.
+ - Optionally, create a contact form.
+
+Add a Contact block to a block region.
+ - Home > Administration > Structure > Block layout
+ - Click 'Place block' of the region you want to place a contact block in.
+ - Search for 'Contact block' in the listed blocks and click 'Place block'.
+ - Select the contact form you want to show in this block.
+ - Save the block.
+ - Optionally, create another contact block.
+
+The personal contact form is built to be used on a pages that 'know' about the
+user. The user 'To' address is determined by using the user ID in the URL. No
+personal contact form is displayed if the user ID is not in the URL.
+For developers: The personal contact form is only loaded if the path contains
+the 'user' placeholder. For example in /user/{user}.
+
+The contact forms of Contact module remain functional at their URL. Use custom
+code or an other module to deny access to these pages.
+
+MAINTAINERS
+-----------
+Current maintainers:
+ * Erik Stielstra (Sutharsan) https://www.drupal.org/user/73854
+
+This project has been sponsored by:
+ * Wizzlern, The Drupal trainers

--- a/docroot/modules/contrib/contact_block/contact_block.info.yml
+++ b/docroot/modules/contrib/contact_block/contact_block.info.yml
@@ -1,0 +1,14 @@
+name: Contact Block
+type: module
+description: "Provides blocks for Contact module's forms."
+package: Other
+# core: 8.x
+dependencies:
+ - block
+ - contact
+
+# Information added by Drupal.org packaging script on 2016-05-30
+version: '8.x-1.2'
+core: '8.x'
+project: 'contact_block'
+datestamp: 1464603244

--- a/docroot/modules/contrib/contact_block/src/Plugin/Block/ContactBlock.php
+++ b/docroot/modules/contrib/contact_block/src/Plugin/Block/ContactBlock.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\contact_block\Plugin\Block\ContactBlock.
+ */
+
+namespace Drupal\contact_block\Plugin\Block;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'ContactBlock' block.
+ *
+ * @Block(
+ *  id = "contact_block",
+ *  admin_label = @Translation("Contact block"),
+ * )
+ */
+class ContactBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The EntityTypeManager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The ConfigFactory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The EntityFormBuilder.
+   *
+   * @var \Drupal\Core\Entity\EntityFormBuilder
+   */
+  protected $entityFormBuilder;
+
+  /**
+   * The Renderer.
+   *
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+  /**
+   * The contact form configuration entity.
+   *
+   * @var \Drupal\contact\Entity\ContactForm
+   */
+  protected $contactForm;
+
+  /**
+   * Constructor for ContactBlock block class.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   * @param EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager.
+   * @param ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param EntityFormBuilderInterface $entity_form_builder
+   *   The entity form builder.
+   * @param RendererInterface $renderer
+   *   The renderer.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, EntityFormBuilderInterface $entity_form_builder, RendererInterface $renderer) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->renderer = $renderer;
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('config.factory'),
+      $container->get('entity.form_builder'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    $contact_form = $this->getContactForm();
+    $contact_message = $this->createContactMessage();
+
+    // Deny access when the configured contact form has been deleted.
+    if (empty($contact_form)) {
+      return AccessResult::forbidden();
+    }
+
+    if ($contact_message->isPersonal()) {
+      /** @var \Drupal\user\Entity\User $user */
+      $user = \Drupal::routeMatch()->getParameter('user');
+
+      // Deny access to the contact form if we are not on a user related page
+      // or we have no access to that page.
+      if (empty($user)) {
+        return AccessResult::forbidden();
+      }
+
+      return AccessResult::allowedIfHasPermission($account, 'access user contact forms');
+    }
+
+    // Access to other contact forms is equal to the permission of the
+    // entity.contact_form.canonical route.
+    return $contact_form->access('view', $account, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    $default_form = $this->configFactory->get('contact.settings')->get('default_form');
+
+    return array(
+      'label' => t('Contact block'),
+      'contact_form' => $default_form,
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+
+    $options = $this->entityTypeManager
+      ->getStorage('contact_form')
+      ->loadMultiple();
+    foreach ($options as $key => $option) {
+      $options[$key] = $option->label();
+    }
+
+    $form['contact_form'] = array(
+      '#type' => 'select',
+      '#title' => $this->t('Contact form'),
+      '#options' => $options,
+      '#default_value' => $this->configuration['contact_form'],
+      '#required' => TRUE,
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->configuration['contact_form'] = $form_state->getValue('contact_form');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $form = array();
+
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = $this->getContactForm();
+    if ($contact_form) {
+      $contact_message = $this->createContactMessage();
+
+      // The personal contact form has a fixed recipient: the user who's
+      // contact page we visit. We use the 'user' property from the URL
+      // to determine this user. For example: user/{user}.
+      if ($contact_message->isPersonal()) {
+        $user = \Drupal::routeMatch()->getParameter('user');
+        $contact_message->set('recipient', $user);
+      }
+
+      $form = $this->entityFormBuilder->getForm($contact_message);
+      $form['#cache']['contexts'][] = 'user.permissions';
+      $this->renderer->addCacheableDependency($form, $contact_form);
+    }
+
+    return $form;
+  }
+
+  /**
+   * Loads the contact form entity.
+   *
+   * @return \Drupal\contact\Entity\ContactForm|null
+   *   The contact form configuration entity. NULL if the entity does not exist.
+   */
+  protected function getContactForm() {
+    if (!isset($this->contactForm)) {
+      if (isset($this->configuration['contact_form'])) {
+        $this->contactForm = $this->entityTypeManager
+          ->getStorage('contact_form')
+          ->load($this->configuration['contact_form']);
+      }
+    }
+    return $this->contactForm;
+  }
+
+  /**
+   * Creates the contact message entity without saving it.
+   *
+   * @return \Drupal\contact\Entity\Message|null
+   *   The contact message entity. NULL if the entity does not exist.
+   */
+  protected function createContactMessage() {
+    $contact_message = NULL;
+
+    $contact_form = $this->getContactForm();
+    if ($contact_form) {
+      $contact_message = $this->entityTypeManager
+        ->getStorage('contact_message')
+        ->create(['contact_form' => $contact_form->id()]);
+    }
+    return $contact_message;
+  }
+}


### PR DESCRIPTION
Adding contact_block module which allows to add contact form as block. Assigned contact us form block to sponser page.
