### PR TITLE
dcd-2019-Sticky-header-broken: header broken on scroll

### DIFF
--- a/docroot/themes/custom/dcd19/css/style.css
+++ b/docroot/themes/custom/dcd19/css/style.css
@@ -8734,7 +8734,7 @@ body {
 }
 
 body.path-frontpage {
-  padding-top: 200px;
+  padding-top: 9%;
 }
 
 #navbar {


### PR DESCRIPTION
=> Minor css changes, on scroll header broken 